### PR TITLE
Update slot property name to avoid incorrect type

### DIFF
--- a/src/VirtualScroll.svelte
+++ b/src/VirtualScroll.svelte
@@ -268,13 +268,13 @@
         </Item>
     {/if}
     <div style="padding: {paddingStyle}">
-        {#each displayItems as data (data[key])}
+        {#each displayItems as dataItem (dataItem[key])}
             <Item
                     on:resize={onItemResized}
-                    uniqueKey={data[key]}
+                    uniqueKey={dataItem[key]}
                     horizontal={isHorizontal}
                     type="item">
-                <slot {data}/>
+                <slot data={dataItem}/>
             </Item>
         {/each}
     </div>


### PR DESCRIPTION
**Thank you**
Hey @v1ack , big fan of your package. It works much better than any other alternative. I am in love with the "pageMode", it works amazing and so practical. This repo deserves more github stars. Very developer friendly, very customizable and easy to use. Thanks for your work.

-------------------------------


**The original problem**
The let:data on the default slot is showing the wrong type as "any[]" (Array), instead of "any".
![image](https://user-images.githubusercontent.com/29447216/126783533-0c1e7e86-4a8b-49be-9e25-163be7c93f7a.png)

And it's coming from here (VirtualScroll.d.ts)
![image](https://user-images.githubusercontent.com/29447216/126783624-16ebb198-51b3-4803-9ce1-a2d664638701.png)

-------------------------------

**Explanation of the changes**
Simply renamed the "data" variable in the "each" loop to "dataItem" to avoid producing incorrect typescript definition on the default slot's property "data". As "data" is declared also at the top as the main component's property, with a type of Array<any>, the slot's "data" property was also producing the same type as Array<any>, where it should just be "any" as it's a single data item.
As a work-around, I renamed the local loop variable to "dataItem" so Sveld treats it as a different variable from the "data" at the top, and produces the correct type definition.

It is a bug from Sveld, but for now this workaround works.
