### PR TITLE
fix: iOS scroll-spring-back boundry condition

### DIFF
--- a/src/VirtualScroll.svelte
+++ b/src/VirtualScroll.svelte
@@ -226,7 +226,7 @@
         const scrollSize = getScrollSize()
 
         // iOS scroll-spring-back behavior will make direction mistake
-        if (offset < 0 || (offset + clientSize > scrollSize + 1) || !scrollSize) {
+        if (offset < 0 || (offset + clientSize > scrollSize) || !scrollSize) {
             return
         }
 


### PR DESCRIPTION
The extra 1px will set the direction to "FRONT" when bouncing back,
which will mess up range checking.