### PR TITLE
Update VirtualScroll.svelte - expose "index" to item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # svelte-virtual-scroll-list changelog
 
+## 1.3.0
+
+- Expose `index` from VirtualScroll component
+
 ## 1.2.0
 
 - Move example to SvelteKit

--- a/README.md
+++ b/README.md
@@ -57,33 +57,33 @@ More examples available in `example` folder
 
 # Comparing to other virtualizing components
 
-| |svelte-virtual-scroll-list|svelte-virtual-list|svelte-tiny-virtual-list|
-|---|---|---|---|
-|handle dynamic size data|+|+|-|
-|scroll methods (to index)|+|-|+|
-|infinity scrolling|two-directional|-|one-directional with another lib|
-|initial scroll position|+|-|+|
-|sticky items|-|-|+|
-|top/bottom slots|+|-|+|
-|reached top/bottom events|+|-|-|
-|document as a list|+|-|-|
+|                           | svelte-virtual-scroll-list | svelte-virtual-list | svelte-tiny-virtual-list         |
+|---------------------------|----------------------------|---------------------|----------------------------------|
+| handle dynamic size data  | +                          | +                   | -                                |
+| scroll methods (to index) | +                          | -                   | +                                |
+| infinity scrolling        | two-directional            | -                   | one-directional with another lib |
+| initial scroll position   | +                          | -                   | +                                |
+| sticky items              | -                          | -                   | +                                |
+| top/bottom slots          | +                          | -                   | +                                |
+| reached top/bottom events | +                          | -                   | -                                |
+| document as a list        | +                          | -                   | -                                |
 
 # API
 
 ## Props
 
-|prop|type|default|description|
-|---|---|---|---|
-|data|object[]|`null`|Source for list|
-|key|string|`id`|Unique key for getting data from `data`|
-|keeps|number|`30`|Count of rendered items|
-|estimateSize|number|`estimateSize`|Estimate size of each item, needs for smooth scrollbar|
-|isHorizontal|boolean|`false`|Scroll direction|
-|pageMode|boolean|`false`|Let virtual list using global document to scroll through the list|
-|start|number|`0`|scroll position start index
-|offset|number|`0`|scroll position offset
-|topThreshold|number|`0`|The threshold to emit `top` event, attention to multiple calls.
-|bottomThreshold|number|`0`|The threshold to emit `bottom` event, attention to multiple calls.
+| prop            | type     | default        | description                                                        |
+|-----------------|----------|----------------|--------------------------------------------------------------------|
+| data            | object[] | `null`         | Source for list                                                    |
+| key             | string   | `id`           | Unique key for getting data from `data`                            |
+| keeps           | number   | `30`           | Count of rendered items                                            |
+| estimateSize    | number   | `estimateSize` | Estimate size of each item, needs for smooth scrollbar             |
+| isHorizontal    | boolean  | `false`        | Scroll direction                                                   |
+| pageMode        | boolean  | `false`        | Let virtual list using global document to scroll through the list  |
+| start           | number   | `0`            | scroll position start index                                        |
+| offset          | number   | `0`            | scroll position offset                                             |
+| topThreshold    | number   | `0`            | The threshold to emit `top` event, attention to multiple calls.    |
+| bottomThreshold | number   | `0`            | The threshold to emit `bottom` event, attention to multiple calls. |
 
 ## Methods
 
@@ -103,22 +103,40 @@ Access to methods by component binding
 
 </details>
 
-|method|arguments|description|
-|---|---|---|
-|scrollToBottom|`none`|Scroll list to bottom|
-|scrollToIndex|`index: number`|Set scroll position to a designated index|
-|scrollToOffset|`offset: number`|Set scroll position to a designated offset|
-|getSize|`id: typeof props.key`|Get the designated item size|
-|getSizes|`none`|Get the total number of stored (rendered) items|
-|getOffset|`none`|Get current scroll offset|
-|getClientSize|`none`|Get wrapper element client viewport size (width or height)|
-|getScrollSize|`none`|Get all scroll size (scrollHeight or scrollWidth)|
-|updatePageModeFront|`none`|When using page mode and virtual list root element offsetTop or offsetLeft change, you need call this method manually|
+| method              | arguments              | description                                                                                                           |
+|---------------------|------------------------|-----------------------------------------------------------------------------------------------------------------------|
+| scrollToBottom      | `none`                 | Scroll list to bottom                                                                                                 |
+| scrollToIndex       | `index: number`        | Set scroll position to a designated index                                                                             |
+| scrollToOffset      | `offset: number`       | Set scroll position to a designated offset                                                                            |
+| getSize             | `id: typeof props.key` | Get the designated item size                                                                                          |
+| getSizes            | `none`                 | Get the total number of stored (rendered) items                                                                       |
+| getOffset           | `none`                 | Get current scroll offset                                                                                             |
+| getClientSize       | `none`                 | Get wrapper element client viewport size (width or height)                                                            |
+| getScrollSize       | `none`                 | Get all scroll size (scrollHeight or scrollWidth)                                                                     |
+| updatePageModeFront | `none`                 | When using page mode and virtual list root element offsetTop or offsetLeft change, you need call this method manually |
 
 ## Events
 
-|event|description|
-|---|---|
-|scroll|Scroll event|
-|top|Top of the list reached|
-|bottom|Bottom of the list reached|
+| event  | description                |
+|--------|----------------------------|
+| scroll | Scroll event               |
+| top    | Top of the list reached    |
+| bottom | Bottom of the list reached |
+
+## Additional
+
+### Get index of current rendering items
+
+```html
+
+<VirtualScroll
+        data={items}
+        key="id"
+        let:data
+        let:index
+>
+    <div>
+        {data.text} {index}
+    </div>
+</VirtualScroll>
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "vite": "^4.3.6"
       },
       "peerDependencies": {
-        "svelte": "^4.0.0"
+        "svelte": ">=3.5.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "virtual-list",
     "virtual-scroll"
   ],
-  "version": "1.2.0",
+  "version": "1.3.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/v1ack/svelte-virtual-scroll-list.git"

--- a/src/lib/VirtualScroll.svelte
+++ b/src/lib/VirtualScroll.svelte
@@ -269,13 +269,13 @@
         </Item>
     {/if}
     <div style="padding: {paddingStyle}" class="virtual-scroll-wrapper">
-        {#each displayItems as dataItem (dataItem[key])}
+        {#each displayItems as dataItem, dataIndex (dataItem[key])}
             <Item
                     on:resize={onItemResized}
                     uniqueKey={dataItem[key]}
                     horizontal={isHorizontal}
                     type="item">
-                <slot data={dataItem}/>
+                <slot data={dataItem} index={dataIndex} />
             </Item>
         {/each}
     </div>


### PR DESCRIPTION
Previously you could not do this:

```
<VirtualScroll let:data let:index> ... </VirtualScroll>
```

now you can.

solves for #8 